### PR TITLE
[WIP] Add website-editing plugin (Phrasing)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem 'devise'
 gem 'rolify'
 #Add privileges
 gem 'cancancan'
+#Add website inline-editing
+gem 'phrasing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    haml (5.1.1)
+      temple (>= 0.8.0)
+      tilt
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -131,6 +134,12 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (1.1.4)
+    phrasing (4.3.0)
+      haml
+      jquery-rails
+      rails (>= 3.2.0)
+      railties (>= 3.2)
+      sass
     popper_js (1.14.5)
     public_suffix (3.0.3)
     puma (3.12.1)
@@ -193,6 +202,11 @@ GEM
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -217,6 +231,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -257,6 +272,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_racer
   pg (>= 0.18, < 2.0)
+  phrasing
   puma (~> 3.11)
   rails (~> 5.2.2, >= 5.2.2.1)
   rails-controller-testing
@@ -275,4 +291,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,7 @@
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
+//= require phrasing
+//= require jquery
+//= require jquery_ujs
+//= require phrasing

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
+ *= require phrasing
  */
 
 // Custom bootstrap variables must be set or imported *before* bootstrap.

--- a/app/helpers/phrasing_helper.rb
+++ b/app/helpers/phrasing_helper.rb
@@ -1,0 +1,13 @@
+module PhrasingHelper
+  # You must implement the can_edit_phrases? method.
+  # Example:
+  #
+  # def can_edit_phrases?
+  #  current_user.is_admin?
+  # end
+
+  def can_edit_phrases?
+    # Currently allowing everyone to edit first
+    true
+  end
+end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -31,7 +31,9 @@
       <%= image_tag('nuansa_logo/2018.jpg', class: 'logo', alt: 'Tasasek') %>
       <br>
       <p>
+      <%= phrase('
         This musical show aims to shine the spotlight on Minangkabau culture, one of the thousands of cultures in Indonesia. The show will be a musical production that is supported by various cultural aspects of Minangkabau cultures such as randai, native costumes, as well as sets. Randai itself is an authentic form of performance originated from Minangkabau that is used in special occasions such as weddings or grand events. NUANSA 2018 will adopt randai as one of the key culture of Minangkabau and it will help bringing authenticity towards the production itself. Randai is an interesting performance which highlights emotions and conflicts with its rapid movements and fast-beat percussions while the dancers sing and shout ethnic languages. This unique form of dance will definitely bring new experience to our audience. Moreover, to ensure the quality of the production, NUANSA 2018 will work together with Singapore Mingakabau Association (SMA) as the cultural advisor to ensure the authenticity of our cultural elements.
+        ') %>
       </p>
     </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
 
   <body>
     <div data-turbolinks="false">
+      <%= render 'phrasing/initializer' %>
       <%= render 'layouts/header' %>
       <%= yield %>
       <%= render 'layouts/footer' %>

--- a/config/initializers/phrasing.rb
+++ b/config/initializers/phrasing.rb
@@ -1,0 +1,11 @@
+Phrasing.setup do |config|
+  config.route = 'phrasing'
+
+  # List all the model attributes you wish to edit with Phrasing, example:
+  # config.whitelist = ["Post.title", "Post.description"]
+  config.whitelist = []
+
+  # You can whitelist all models, but it's not recommended.
+  # Read here: https://github.com/infinum/phrasing#security
+  config.allow_update_on_all_models_and_attributes = false
+end

--- a/db/migrate/20190616112027_create_phrasing_phrases.rb
+++ b/db/migrate/20190616112027_create_phrasing_phrases.rb
@@ -1,0 +1,10 @@
+class CreatePhrasingPhrases < ActiveRecord::Migration[5.2]
+  def change
+    create_table :phrasing_phrases do |t|
+      t.string :locale
+      t.string :key
+      t.text :value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190616112028_create_phrasing_phrase_versions.rb
+++ b/db/migrate/20190616112028_create_phrasing_phrase_versions.rb
@@ -1,0 +1,10 @@
+class CreatePhrasingPhraseVersions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :phrasing_phrase_versions do |t|
+      t.integer :phrasing_phrase_id
+      t.text :value
+      t.timestamps
+    end
+    add_index :phrasing_phrase_versions, :phrasing_phrase_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_08_125610) do
+ActiveRecord::Schema.define(version: 2019_06_16_112028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,24 @@ ActiveRecord::Schema.define(version: 2019_04_08_125610) do
     t.text "logo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["title"], name: "index_past_events_on_title", unique: true
-    t.index ["year"], name: "index_past_events_on_year", unique: true
+    t.index ["title"], name: "index_events_on_title", unique: true
+    t.index ["year"], name: "index_events_on_year", unique: true
+  end
+
+  create_table "phrasing_phrase_versions", force: :cascade do |t|
+    t.integer "phrasing_phrase_id"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["phrasing_phrase_id"], name: "index_phrasing_phrase_versions_on_phrasing_phrase_id"
+  end
+
+  create_table "phrasing_phrases", force: :cascade do |t|
+    t.string "locale"
+    t.string "key"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "roles", force: :cascade do |t|


### PR DESCRIPTION
Part of Issue #32. 

Using the gem [Phrasing](https://github.com/infinum/phrasing). The article about it can be found [here](https://infinum.co/the-capsized-eight/simple-ruby-on-rails-content-editing), and the video demonstration can be viewed [here](https://www.youtube.com/watch?v=wOqzulEzNsY&feature=youtu.be). 

This gem supports authentication such that only admin can edit the files but in the current PR I have set it such that everybody can edit (for easy demo purposes since we don't need to log in as admin). It seems like the gem also supports versioning so that we can revert to a content we have in the past. 
I have also applied the plugin to the 2018 NUANSA event description (in commit ae6885f9396881613ac5b2ff6004e952668c6b70) for others to try out whether this is feasible. 

Currently, this is one of the few plugins I found that can support direct editing on websites based on Ruby on Rails. The disadvantage to this plugin based on what I can understand is that all editable content must be wrapped with `<%= phrase('the original content here') %>`. This can be troublesome in terms of maintenance since we have to continuously include `<%= phrase() %>` to past and future content