### PR TITLE
Create Event Info

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -14,6 +14,7 @@ class Admin::EventsController < ApplicationController
   # GET /events/new
   def new
     @event = Event.new
+    @event.build_event_info
   end
 
   # GET /events/1/edit
@@ -58,6 +59,10 @@ class Admin::EventsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def event_params
-      params.require(:event).permit(:title, :subtitle, :description, :year, :logo)
+      params.require(:event).permit(:title, :subtitle, :overview, :year, :logo,
+        event_info_attributes: [:id, :synopsis, :description, :video_link])
+        .tap do|event_params|
+          event_params.require(:event_info_attributes)
+        end
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,4 @@
 class Event < ApplicationRecord
   has_one_attached :logo
+  has_one :event_info, dependent: :destroy, foreign_key: 'year'
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
   has_one_attached :logo
-  has_one :event_info, dependent: :destroy, foreign_key: 'year'
+  has_one :event_info, dependent: :destroy, foreign_key: :year,
+    primary_key: :year, inverse_of: :event
+  accepts_nested_attributes_for :event_info
 end

--- a/app/models/event_info.rb
+++ b/app/models/event_info.rb
@@ -1,3 +1,4 @@
 class EventInfo < ApplicationRecord
-  belongs_to  :event
+  self.table_name = "event_info"
+  belongs_to  :event, foreign_key: :year, primary_key: :year, touch: true
 end

--- a/app/models/event_info.rb
+++ b/app/models/event_info.rb
@@ -1,0 +1,3 @@
+class EventInfo < ApplicationRecord
+  belongs_to  :event
+end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -21,7 +21,7 @@
   <%= form.text_area :overview %> <br>
 
   <%= form.label :year, "Year" %> <br>
-  <%= form.number_field :year, :required => true%> <br>
+  <%= form.number_field :year, :required => true %> <br>
 
   <%= form.label :logo, "Logo" %> <br>
   <%= form.file_field :logo, accept: 'image/png,image/gif,image/jpeg' %> <br>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -24,7 +24,18 @@
   <%= form.number_field :year, :required => true%> <br>
 
   <%= form.label :logo, "Logo" %> <br>
-  <%= form.file_field :logo, accept: 'image/png,image/gif,image/jpeg' %>
+  <%= form.file_field :logo, accept: 'image/png,image/gif,image/jpeg' %> <br>
+
+  <%= form.fields_for :event_info do |event_info_form| %>
+    <%= event_info_form.label :video_link %> <br>
+    <%= event_info_form.text_field :video_link %> <br>
+
+    <%= event_info_form.label :synopsis %> <br>
+    <%= event_info_form.text_area :synopsis %> <br>
+
+    <%= event_info_form.label :description, "Full Description" %> <br>
+    <%= event_info_form.text_area :description %> <br>
+  <% end %>
 
   <div class="actions">
     <%= form.submit "Upload" %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -17,8 +17,8 @@
   <%= form.label :subtitle, "Subtitle" %> <br>
   <%= form.text_field :subtitle %> <br>
 
-  <%= form.label :description, "Description" %> <br>
-  <%= form.text_area :description %> <br>
+  <%= form.label :overview, "Short Description" %> <br>
+  <%= form.text_area :overview %> <br>
 
   <%= form.label :year, "Year" %> <br>
   <%= form.number_field :year, :required => true%> <br>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -8,20 +8,47 @@
 
   <tr style="border: 2px solid black">
     <td style="border: 2px solid black"> YEAR </td>
-    <td> <% @event.year %> </td>
+    <td> <%= @event.year %> </td>
   </tr>
 
   <tr style="border: 2px solid black">
     <td style="border: 2px solid black"> ID </td>
-    <td> <% @event.id %> </td>
+    <td> <%= @event.id %> </td>
   </tr>
 
-  <% if @event.logo.attached? %>
-    <tr style="border: 2px solid black">
-      <td style="border: 2px solid black"> LOGO </td>
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> SUBTITLE </td>
+    <td> <%= @event.subtitle %>  </td>
+  </tr>
+
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> OVERVIEW </td>
+    <td> <%= @event.overview %>  </td>
+  </tr>
+
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> LOGO </td>
+    <% if @event.logo.attached? %>
       <td> <%= image_tag(@event.logo, width: '100px') %> </td>
-    </tr>
-  <% end %>
+    <% else %>
+      <td> NO LOGO </td>
+    <% end %>
+  </tr>
+
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> DESCRIPTION </td>
+    <td> <%= @event.event_info.description %> </td>
+  </tr>
+
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> SYNOPSIS </td>
+    <td> <%= @event.event_info.synopsis %> </td>
+  </tr>
+
+  <tr style="border: 2px solid black">
+    <td style="border: 2px solid black"> VIDEO LINK </td>
+    <td> <%= @event.event_info.video_link %> </td>
+  </tr>
 </table>
 
 <%= link_to 'Back To Index', admin_events_path %>

--- a/db/migrate/20190408125610_create_events.rb
+++ b/db/migrate/20190408125610_create_events.rb
@@ -3,7 +3,7 @@ class CreateEvents < ActiveRecord::Migration[5.2]
     create_table :events do |t|
       t.string :title,      null: false, default: ""
       t.string :subtitle
-      t.text :description
+      t.text :overview
       t.integer :year,      null: false, default: ""
 
       t.timestamps

--- a/db/migrate/20190703180302_create_event_info.rb
+++ b/db/migrate/20190703180302_create_event_info.rb
@@ -1,0 +1,12 @@
+class CreateEventInfo < ActiveRecord::Migration[5.2]
+  def change
+    create_table :event_info do |t|
+      t.text :synopsis
+      t.text :description
+      t.string :video_link
+      t.integer :year
+      t.foreign_key :events, column: :year, primary_key: "year"
+    end
+    add_index :event_info, :year, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_02_182506) do
+ActiveRecord::Schema.define(version: 2019_07_03_180302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,12 @@ ActiveRecord::Schema.define(version: 2019_07_02_182506) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  create_table "event_info", force: :cascade do |t|
+    t.text "synopsis"
+    t.text "description"
+    t.string "video_link"
+    t.integer "year"
+    t.index ["year"], name: "index_event_info_on_year", unique: true
   end
 
   create_table "events", force: :cascade do |t|
@@ -87,4 +93,5 @@ ActiveRecord::Schema.define(version: 2019_07_02_182506) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "event_info", "events", column: "year", primary_key: "year"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2019_07_02_182506) do
   create_table "events", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.string "subtitle"
-    t.text "description"
+    t.text "overview"
     t.integer "year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 2019_07_03_180302) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
   create_table "event_info", force: :cascade do |t|
     t.text "synopsis"
     t.text "description"

--- a/spec/factories/event_info.rb
+++ b/spec/factories/event_info.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :event_info do
+    
+  end
+end

--- a/spec/models/event_info_spec.rb
+++ b/spec/models/event_info_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EventInfo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR does the following changes:
- Renaming event's description to overview
- Created event_info table. Consisted of 5 column (id, synopsis, description, video_link, year) and 2 indexes (for id and year). Year column is a foreign key column.
- Configured association between event and event_info. In more details, configured the foreign key as year (instead of the default, i.e. id), configured the destroy method to be cascade delete and configured such that event's updated_at updated accordingly when only event_info updated.
- Adjust controller. One of the adjustment is to change the whitelisting parameter to permit event_info's attribute while also requiring event_info_attribute to be submitted so that whenever event was created, event_info must be created as well.
- Modify form to include event_info's form. (a.k.a nested form)
- Modify Show.html to include event_info